### PR TITLE
Adds support for mirror packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.yarnpkg.com/

--- a/lib/api.js
+++ b/lib/api.js
@@ -65,4 +65,8 @@ export default class GitLab {
   writeAccessLevel () {
     return 30; // DEVELOPER
   }
+
+  publishAccessLevel () {
+    return 40; // MASTER
+  }
 }

--- a/lib/authorizer.js
+++ b/lib/authorizer.js
@@ -4,6 +4,7 @@ import parseGitUrl from 'github-url-from-git';
 import GitLab from './api';
 import Session from './session';
 import error from './error';
+import parseRepo from 'parse-repo';
 
 export default class Authorizer {
   /**
@@ -16,6 +17,7 @@ export default class Authorizer {
     if (!opts.debug) { this.session = opts.session || new Session(opts); }
     this.frontDoorHost = opts.frontDoorHost || process.env.FRONT_DOOR_HOST;
     this.sharedFetchSecret = opts.sharedFetchSecret || process.env.SHARED_FETCH_SECRET;
+    this.gitLabURL = urlParser.parse(this.frontDoorHost);
   }
 
   /**
@@ -42,12 +44,10 @@ export default class Authorizer {
         cb(null, body.versions[body['dist-tags'].latest]);
       });
     }
-    try {
-      // lookup package.json
-      const response = await got(urlParser.resolve(frontDoorHost, credentials.path + '?sharedFetchSecret=' + sharedFetchSecret), { json: true });
-      if (response.body.repository) return cb(null, response.body);
-    } catch (e) {
-      cb(e);
+    // Lookup package.json
+    const response = await got(urlParser.resolve(frontDoorHost, credentials.path + '?sharedFetchSecret=' + sharedFetchSecret), { json: true });
+    if (response.body.repository) {
+      return response.body;
     }
   }
 
@@ -69,36 +69,57 @@ export default class Authorizer {
   }
 
   async authorize (credentials, cb) {
-    let token = Authorizer.extractToken(credentials);
-    if (!token) return error.defer(cb, 401);
-
-    let self = this;
+    const token = Authorizer.extractToken(credentials);
+    if (!token) {
+      return error.defer(cb, 401);
+    }
+    // Determine required access permissions
     let requiredAccessLevel;
     switch (credentials.method) {
       case 'GET':
-        requiredAccessLevel = self.api.readAccessLevel();
+        requiredAccessLevel = this.api.readAccessLevel();
         break;
       case 'PUT':
       case 'POST':
       case 'DELETE':
-        requiredAccessLevel = self.api.writeAccessLevel();
+        requiredAccessLevel = this.api.publishAccessLevel();
         break;
       default:
         return error.defer(cb, 405, 'Unsupported method: ' + credentials.method);
     }
-    await Authorizer.loadPackageJson(
-      credentials,
-      self.frontDoorHost,
-      self.sharedFetchSecret,
-      (er, packageJson) => this.authenticateGitLab(er, packageJson, token, requiredAccessLevel, cb)
-    );
+    // Load the project's package.json
+    try {
+      const packageJSON = await Authorizer.loadPackageJson(credentials, this.frontDoorHost, this.sharedFetchSecret);
+      if (!packageJSON.repository.url) {
+        return cb("No repo URL specified in package.json");
+      }
+      // Check if the module is hosted in our GitLab server
+      const repoURL = parseRepo(packageJSON.repository.url);
+      if (repoURL.host !== this.gitLabURL.host) {
+        if (requiredAccessLevel === this.api.readAccessLevel()) {
+          // Reading a third party library from the NPME server. This is
+          // generally the case when NPME is setup to mirror / lazy cache
+          // public modules and the user has configured their local npm /
+          // yarn to pull all modules from the internal server.
+          return cb(null, true);
+        } else {
+          // Attempting to write a public module to the internal npm server.
+          return cb("Cannot publish over modules internally. Please publish a new version of the public module to npmjs.org and pull the new version through the internal server, or publish as new internal module.", false);
+        }
+      }
+
+      return this.authenticateGitLab(packageJSON, token, requiredAccessLevel, cb);
+    } catch (err) {
+      return cb(err);
+    }
   }
 
-  async authenticateGitLab(er, packageJson, token, requiredAccessLevel, cb) {
-    if (er) return cb(er);
-
+  async authenticateGitLab(packageJson, token, requiredAccessLevel, cb) {
       const orgRepo = Authorizer.parseRepoUrl(packageJson);
-      if (typeof orgRepo === 'string') return cb(error.forCode(400, orgRepo));
+      
+      if (typeof orgRepo === 'string') {
+        return cb(error.forCode(400, orgRepo));
+      }
 
       try {
         const project = await this.api.projectInfo(token, orgRepo.org, orgRepo.repo);
@@ -106,9 +127,9 @@ export default class Authorizer {
           let authorized = project.permissions &&
             ((project.permissions.project_access && project.permissions.project_access.access_level >= requiredAccessLevel) ||
             (project.permissions.group_access && project.permissions.group_access.access_level >= requiredAccessLevel));
-          cb(null, authorized);
+          return cb(null, authorized);
       } catch (err) {
-        cb(err);
+        return cb(err);
       }
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "dotenv": "^4.0.0",
     "github-url-from-git": "^1.4.0",
     "got": "^6.3.0",
+    "parse-repo": "^1.0.4",
     "redis": "^2.6.0-2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3988,6 +3988,10 @@ parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
 
+parse-repo@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/parse-repo/-/parse-repo-1.0.4.tgz#74b91d2cb8675d11b99976a0065f6ce17fa1bcc8"
+
 parse5@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"


### PR DESCRIPTION
When package mirroring is enabled in npme the module previously did not allow for pulling scoped packaged. This checks where the package being authorized is hosted and if it isn't our source hosting then it allows reads, assuming that we are pulling a public package being mirror in GitLab. 